### PR TITLE
Adding option to hide buy section on vertical market pages

### DIFF
--- a/app/admin/vertical_market.rb
+++ b/app/admin/vertical_market.rb
@@ -11,6 +11,7 @@ ActiveAdmin.register VerticalMarket do
     :lead_form_content,
     :live,
     :retail,
+    :hide_buy_section,
     case_study_vertical_markets_attributes: [:id, :case_study_id, :_destroy]
 
 
@@ -69,7 +70,6 @@ ActiveAdmin.register VerticalMarket do
   form html: { multipart: true} do |f|
     f.inputs do
       f.input :live
-      f.input :retail, label: "Offer retailer/ecommerce links with this vertical market."
       f.input :parent
       f.input :name, hint: "Maximum characters: 20", input_html: {maxlength: 20}
       f.input :headline, hint: "Maximum characters: 70", input_html: { maxlength: 70 }
@@ -77,7 +77,9 @@ ActiveAdmin.register VerticalMarket do
       f.input :background, hint: "Used for top-level verticals on the homepage and on the category page."
       f.input :description, hint: "Maximum recommended characters: 650", input_html: { rows: 10 }
       f.input :extra_content, hint: "Appears after the case studies", input_html: { rows: 10, class: "mceEditor"}
-      f.input :lead_form_content, input_html: { class: "mceEditor"}
+      f.input :retail, label: "Offer retailer/ecommerce links with this vertical market."
+      f.input :lead_form_content, hint: "Replaces the retailer links if present and the default lead form.", input_html: { class: "mceEditor"}
+      f.input :hide_buy_section, label: "Hide both the retailer links and the lead capture form."
     end
     f.has_many :case_study_vertical_markets, heading: "Case Studies", new_record: "Add a case study" do |s|
       s.input :id, as: :hidden

--- a/app/views/vertical_markets/_buy.html.erb
+++ b/app/views/vertical_markets/_buy.html.erb
@@ -1,95 +1,96 @@
 <a name="buy"></a>
 
-<% if vertical_market.lead_form_content.present? %>
-
-  <div class="container buy-container" data-magellan-destination="buy">
-    <div class="row">
-      <div class="large-8 large-offset-2 medium-10 medium-offset-1 small-12 columns">
-        <%= raw vertical_market.lead_form_content %>
-      </div>
-    </div>
-  </div>
-
-<% elsif vertical_market.retail? %>
-
-  <% retailers = current_locale.online_retailers %>
-  <% if SiteSetting.set_for_locale?("store_link", current_locale.key) || retailers.count > 0 %>
+<% unless vertical_market.hide_buy_section? %>
+  <% if vertical_market.lead_form_content.present? %>
 
     <div class="container buy-container" data-magellan-destination="buy">
       <div class="row">
-        <div class="large-8 large-offset-2 columns text-center">
+        <div class="large-8 large-offset-2 medium-10 medium-offset-1 small-12 columns">
+          <%= raw vertical_market.lead_form_content %>
+        </div>
+      </div>
+    </div>
 
-          <% if SiteSetting.set_for_locale?("store_link", current_locale.key) %>
-            <h4><%= SiteSetting.value("buy_direct_from_harman_headline") %></h4>
-            <br/>
-            <%= link_to t('home_page.shop_now'), SiteSetting.value("store_link"), target: "_blank", class: "radius button" %>
-            <br/>
-          <% end %>
+  <% elsif vertical_market.retail? %>
 
-          <% if retailers.count > 0 %>
-            <h4><%= SiteSetting.value("buy_from_online_retailer_headline") %></h4>
-            <br/>
-            <% retailers.order("RAND()").each do |online_retailer| %>
-              <%= link_to online_retailer.url, class: "retailer", target: "_blank" do %>
-                <% if online_retailer.logo.present? || ENV['show_placeholders'] == "true" %>
-                  <%= image_tag online_retailer.logo.url(:medium), alt: online_retailer.name %>
-                <% else %>
-                  <%= online_retailer.name %>
+    <% retailers = current_locale.online_retailers %>
+    <% if SiteSetting.set_for_locale?("store_link", current_locale.key) || retailers.count > 0 %>
+
+      <div class="container buy-container" data-magellan-destination="buy">
+        <div class="row">
+          <div class="large-8 large-offset-2 columns text-center">
+
+            <% if SiteSetting.set_for_locale?("store_link", current_locale.key) %>
+              <h4><%= SiteSetting.value("buy_direct_from_harman_headline") %></h4>
+              <br/>
+              <%= link_to t('home_page.shop_now'), SiteSetting.value("store_link"), target: "_blank", class: "radius button" %>
+              <br/>
+            <% end %>
+
+            <% if retailers.count > 0 %>
+              <h4><%= SiteSetting.value("buy_from_online_retailer_headline") %></h4>
+              <br/>
+              <% retailers.order("RAND()").each do |online_retailer| %>
+                <%= link_to online_retailer.url, class: "retailer", target: "_blank" do %>
+                  <% if online_retailer.logo.present? || ENV['show_placeholders'] == "true" %>
+                    <%= image_tag online_retailer.logo.url(:medium), alt: online_retailer.name %>
+                  <% else %>
+                    <%= online_retailer.name %>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>
-          <% end %>
 
+          </div>
+        </div>
+      </div>
+
+    <% end %>
+
+  <% else %>
+
+    <div class="container buy-container" data-magellan-destination="buy">
+      <div class="row">
+        <div class="large-8 large-offset-2 medium-10 medium-offset-1 small-12 columns">
+          <h2 class="text-center"><%= SiteSetting.value("leadgen-title") %></h2>
+          <p class="text-center">
+            <%= SiteSetting.value("leadgen-intro") %>
+          </p>
+          <div class="panel">
+            <%
+              body_label ||= Lead.human_attribute_name("project_description")
+            %>
+            <%= simple_form_for @lead do |f| %>
+              <%= f.input :vertical_market_id, as: :hidden %>
+              <div class="row">
+                <div class="medium-6 small-12 columns">
+                  <%= f.input :name %>
+                </div>
+                <div class="medium-6 small-12 columns">
+                  <%= f.input :company %>
+                </div>
+              </div>
+              <div class="row">
+                <div class="medium-6 small-12 columns">
+                  <%= f.input :email %>
+                </div>
+                <div class="medium-6 small-12 columns">
+                  <%= f.input :location %>
+                </div>
+              </div>
+              <div class="row">
+                <div class="medium-6 small-12 columns">
+                  <%= f.input :phone %>
+                </div>
+              </div>
+              <%= f.input :project_description, label: body_label, input_html: { rows: 6 } %>
+              <%= recaptcha_tags %><br/>
+              <%= f.button :submit, t('submit').titleize, class: "medium radius button" %>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>
 
   <% end %>
-
-<% else %>
-
-  <div class="container buy-container" data-magellan-destination="buy">
-    <div class="row">
-      <div class="large-8 large-offset-2 medium-10 medium-offset-1 small-12 columns">
-        <h2 class="text-center"><%= SiteSetting.value("leadgen-title") %></h2>
-        <p class="text-center">
-          <%= SiteSetting.value("leadgen-intro") %>
-        </p>
-        <div class="panel">
-          <%
-            body_label ||= Lead.human_attribute_name("project_description")
-          %>
-          <%= simple_form_for @lead do |f| %>
-            <%= f.input :vertical_market_id, as: :hidden %>
-            <div class="row">
-              <div class="medium-6 small-12 columns">
-                <%= f.input :name %>
-              </div>
-              <div class="medium-6 small-12 columns">
-                <%= f.input :company %>
-              </div>
-            </div>
-            <div class="row">
-              <div class="medium-6 small-12 columns">
-                <%= f.input :email %>
-              </div>
-              <div class="medium-6 small-12 columns">
-                <%= f.input :location %>
-              </div>
-            </div>
-            <div class="row">
-              <div class="medium-6 small-12 columns">
-                <%= f.input :phone %>
-              </div>
-            </div>
-            <%= f.input :project_description, label: body_label, input_html: { rows: 6 } %>
-            <%= recaptcha_tags %><br/>
-            <%= f.button :submit, t('submit').titleize, class: "medium radius button" %>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  </div>
-
 <% end %>
-

--- a/db/migrate/20170131181643_add_hide_buy_section_to_vertical_markets.rb
+++ b/db/migrate/20170131181643_add_hide_buy_section_to_vertical_markets.rb
@@ -1,0 +1,5 @@
+class AddHideBuySectionToVerticalMarkets < ActiveRecord::Migration[5.0]
+  def change
+    add_column :vertical_markets, :hide_buy_section, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170116224253) do
+ActiveRecord::Schema.define(version: 20170131181643) do
 
-  create_table "active_admin_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "active_admin_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "namespace"
     t.text     "body",          limit: 65535
     t.string   "resource_id",                 null: false
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
   end
 
-  create_table "admin_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "admin_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "email",                  default: "",    null: false
     t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true, using: :btree
   end
 
-  create_table "artists", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "artists", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name"
     t.text     "description",        limit: 65535
     t.text     "overview",           limit: 65535
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["slug"], name: "index_artists_on_slug", unique: true, using: :btree
   end
 
-  create_table "available_locales", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "available_locales", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name"
     t.string   "key"
     t.datetime "created_at", null: false
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["slug"], name: "index_available_locales_on_slug", using: :btree
   end
 
-  create_table "brand_news_articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "brand_news_articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "brand_id"
     t.integer  "news_article_id"
     t.datetime "created_at",      null: false
@@ -82,7 +82,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["news_article_id"], name: "index_brand_news_articles_on_news_article_id", using: :btree
   end
 
-  create_table "brand_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "brand_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "brand_id",                                   null: false
     t.string   "locale",                                     null: false
     t.datetime "created_at",                                 null: false
@@ -93,7 +93,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["locale"], name: "index_brand_translations_on_locale", using: :btree
   end
 
-  create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "name"
     t.string   "url"
     t.datetime "created_at"
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["slug"], name: "index_brands_on_slug", using: :btree
   end
 
-  create_table "case_studies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "case_studies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "banner_file_name"
@@ -138,7 +138,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.datetime "banner_updated_at"
   end
 
-  create_table "case_study_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "case_study_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "case_study_id",               null: false
     t.string   "locale",                      null: false
     t.datetime "created_at",                  null: false
@@ -151,14 +151,14 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["locale"], name: "index_case_study_translations_on_locale", using: :btree
   end
 
-  create_table "case_study_vertical_markets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "case_study_vertical_markets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "case_study_id"
     t.integer  "vertical_market_id"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
   end
 
-  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "delayed_jobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer  "priority",                 default: 0, null: false
     t.integer  "attempts",                 default: 0, null: false
     t.text     "handler",    limit: 65535,             null: false
@@ -173,7 +173,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
 
-  create_table "event_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "event_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "event_id",                   null: false
     t.string   "locale",                     null: false
     t.datetime "created_at",                 null: false
@@ -186,7 +186,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["locale"], name: "index_event_translations_on_locale", using: :btree
   end
 
-  create_table "events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "events", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.date     "start_on"
     t.date     "end_on"
     t.boolean  "featured"
@@ -204,7 +204,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["original_locale_id"], name: "index_events_on_original_locale_id", using: :btree
   end
 
-  create_table "friendly_id_slugs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "friendly_id_slugs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "slug",                      null: false
     t.integer  "sluggable_id",              null: false
     t.string   "sluggable_type", limit: 50
@@ -216,7 +216,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
   end
 
-  create_table "landing_page_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "landing_page_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "landing_page_id",               null: false
     t.string   "locale",                        null: false
     t.datetime "created_at",                    null: false
@@ -233,7 +233,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["locale"], name: "index_landing_page_translations_on_locale", using: :btree
   end
 
-  create_table "landing_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "landing_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
     t.boolean  "hide_title"
@@ -248,7 +248,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["original_locale_id"], name: "index_landing_pages_on_original_locale_id", using: :btree
   end
 
-  create_table "leads", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "leads", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "name"
     t.string   "company"
     t.string   "email"
@@ -261,7 +261,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.integer  "vertical_market_id"
   end
 
-  create_table "locale_translators", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "locale_translators", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "available_locale_id"
     t.integer  "admin_user_id"
     t.datetime "created_at",          null: false
@@ -270,7 +270,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["available_locale_id"], name: "index_locale_translators_on_available_locale_id", using: :btree
   end
 
-  create_table "media_library_access_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "media_library_access_requests", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "first_name"
     t.string   "last_name"
     t.string   "email"
@@ -284,7 +284,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.datetime "updated_at",         null: false
   end
 
-  create_table "menu_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "menu_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "locale_id"
     t.string   "title"
     t.string   "link"
@@ -296,7 +296,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["locale_id"], name: "index_menu_items_on_locale_id", using: :btree
   end
 
-  create_table "news_articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "news_articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "locale_id"
     t.string   "title"
     t.text     "body",                    limit: 65535
@@ -313,7 +313,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["locale_id"], name: "index_news_articles_on_locale_id", using: :btree
   end
 
-  create_table "online_retailers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "online_retailers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "name"
     t.string   "slug"
     t.string   "url"
@@ -328,7 +328,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["slug"], name: "index_online_retailers_on_slug", using: :btree
   end
 
-  create_table "product_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "product_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "product_id",                null: false
     t.string   "locale",                    null: false
     t.datetime "created_at",                null: false
@@ -340,7 +340,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["product_id"], name: "index_product_translations_on_product_id", using: :btree
   end
 
-  create_table "product_type_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "product_type_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "product_type_id",               null: false
     t.string   "locale",                        null: false
     t.datetime "created_at",                    null: false
@@ -352,12 +352,12 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["product_type_id"], name: "index_product_type_translations_on_product_type_id", using: :btree
   end
 
-  create_table "product_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "product_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "url"
     t.string   "photo_file_name"
     t.string   "photo_content_type"
@@ -369,7 +369,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.string   "ecommerce_id"
   end
 
-  create_table "reference_system_product_type_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "reference_system_product_type_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer  "reference_system_product_type_id"
     t.integer  "product_id"
     t.datetime "created_at"
@@ -377,7 +377,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["reference_system_product_type_id"], name: "r_s_p_t_id", using: :btree
   end
 
-  create_table "reference_system_product_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "reference_system_product_types", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer  "reference_system_id"
     t.integer  "product_type_id"
     t.integer  "quantity"
@@ -388,7 +388,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["reference_system_id"], name: "index_reference_system_product_types_on_reference_system_id", using: :btree
   end
 
-  create_table "reference_system_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "reference_system_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "reference_system_id",                 null: false
     t.string   "locale",                              null: false
     t.datetime "created_at",                          null: false
@@ -402,7 +402,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["reference_system_id"], name: "index_reference_system_translations_on_reference_system_id", using: :btree
   end
 
-  create_table "reference_systems", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "reference_systems", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer  "vertical_market_id"
     t.integer  "position"
     t.datetime "created_at"
@@ -418,7 +418,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["vertical_market_id"], name: "index_reference_systems_on_vertical_market_id", using: :btree
   end
 
-  create_table "resources", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "resources", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name"
     t.string   "attachment_file_name"
     t.string   "attachment_content_type"
@@ -434,7 +434,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.integer  "image_file_size"
   end
 
-  create_table "service_center_service_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "service_center_service_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer  "service_center_id"
     t.integer  "service_group_id"
     t.datetime "created_at",        null: false
@@ -443,7 +443,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["service_group_id"], name: "index_service_center_service_groups_on_service_group_id", using: :btree
   end
 
-  create_table "service_centers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "service_centers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "name"
     t.string   "address"
     t.string   "city"
@@ -461,7 +461,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["active"], name: "index_service_centers_on_active", using: :btree
   end
 
-  create_table "service_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "service_groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "name"
     t.integer  "brand_id"
     t.datetime "created_at", null: false
@@ -469,7 +469,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["brand_id"], name: "index_service_groups_on_brand_id", using: :btree
   end
 
-  create_table "site_setting_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "site_setting_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "site_setting_id",               null: false
     t.string   "locale",                        null: false
     t.datetime "created_at",                    null: false
@@ -479,14 +479,14 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["site_setting_id"], name: "index_site_setting_translations_on_site_setting_id", using: :btree
   end
 
-  create_table "site_settings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "site_settings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["name"], name: "index_site_settings_on_name", unique: true, using: :btree
   end
 
-  create_table "slides", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "slides", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name"
     t.integer  "locale_id"
     t.integer  "position"
@@ -509,7 +509,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.datetime "updated_at",                              null: false
   end
 
-  create_table "taggings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "taggings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "tag_id"
     t.integer  "taggable_id"
     t.string   "taggable_type"
@@ -521,13 +521,13 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
   end
 
-  create_table "tags", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string  "name"
+  create_table "tags", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string  "name",                       collation: "utf8_bin"
     t.integer "taggings_count", default: 0
     t.index ["name"], name: "index_tags_on_name", unique: true, using: :btree
   end
 
-  create_table "training_content_page_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "training_content_page_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "training_content_page_id",               null: false
     t.string   "locale",                                 null: false
     t.datetime "created_at",                             null: false
@@ -543,7 +543,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["training_content_page_id"], name: "index_d73f0ce584cd69245ae320eec6d9ea12689da0e6", using: :btree
   end
 
-  create_table "training_content_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "training_content_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
     t.boolean  "hide_title"
@@ -558,7 +558,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["original_locale_id"], name: "index_training_content_pages_on_original_locale_id", using: :btree
   end
 
-  create_table "venue_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "venue_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "venue_id",                  null: false
     t.string   "locale",                    null: false
     t.datetime "created_at",                null: false
@@ -570,14 +570,14 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["venue_id"], name: "index_venue_translations_on_venue_id", using: :btree
   end
 
-  create_table "venues", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "venues", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.string   "left"
     t.string   "top"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "vertical_market_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "vertical_market_translations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "vertical_market_id",               null: false
     t.string   "locale",                           null: false
     t.datetime "created_at",                       null: false
@@ -592,7 +592,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.index ["vertical_market_id"], name: "index_vertical_market_translations_on_vertical_market_id", using: :btree
   end
 
-  create_table "vertical_markets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "vertical_markets", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer  "parent_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -606,6 +606,7 @@ ActiveRecord::Schema.define(version: 20170116224253) do
     t.integer  "background_file_size"
     t.datetime "background_updated_at"
     t.boolean  "retail",                  default: false
+    t.boolean  "hide_buy_section"
     t.index ["parent_id"], name: "index_vertical_markets_on_parent_id", using: :btree
   end
 


### PR DESCRIPTION
Per Jessica's request, making it possible to have neither the retailer links nor the lead capture form on the bottom of some vertical market pages.